### PR TITLE
Center board and scale tiles to viewport

### DIFF
--- a/pitch-interval-memory-matching/script.js
+++ b/pitch-interval-memory-matching/script.js
@@ -31,6 +31,22 @@ const GRID_SIZES = {
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 let timerInterval, startTime;
 
+function setBoardSize(cols, rows){
+    const gap = 10; // match CSS gap
+    const header = document.querySelector('h1').offsetHeight;
+    const controls = document.getElementById('controls').offsetHeight;
+    const timer = document.getElementById('timer').offsetHeight;
+    const availableWidth = window.innerWidth - 20; // small margin
+    const availableHeight = window.innerHeight - header - controls - timer - 20;
+    const tileSize = Math.min(
+        (availableWidth - gap * (cols - 1)) / cols,
+        (availableHeight - gap * (rows - 1)) / rows
+    );
+    const board = document.getElementById('game');
+    board.style.gridTemplateColumns = `repeat(${cols}, ${tileSize}px)`;
+    board.style.gridAutoRows = `${tileSize}px`;
+}
+
 function midiToFreq(m){
     return 440 * Math.pow(2, (m-69)/12);
 }
@@ -108,8 +124,8 @@ function generateTiles(diff){
 function buildBoard(diff){
     const board = document.getElementById('game');
     board.innerHTML='';
-    const {tiles, cols} = generateTiles(diff);
-    board.style.gridTemplateColumns = `repeat(${cols}, 80px)`;
+    const {tiles, cols, rows} = generateTiles(diff);
+    setBoardSize(cols, rows);
     tiles.forEach((t,i)=>{
         const div = document.createElement('div');
         div.className = 'tile';
@@ -147,7 +163,8 @@ function initGame(){
     if(practice){
         const intervals = INTERVAL_SETS[diff];
         const cols = Math.ceil(Math.sqrt(intervals.length));
-        board.style.gridTemplateColumns = `repeat(${cols}, 80px)`;
+        const rows = Math.ceil(intervals.length/cols);
+        setBoardSize(cols, rows);
         intervals.forEach(interval => {
             const div = document.createElement('div');
             div.className = 'tile revealed';
@@ -213,6 +230,24 @@ function initGame(){
         });
         if(timed) startTimer();
     }
+    adjustBoard();
 }
 
 document.getElementById('start').addEventListener('click', initGame);
+
+function adjustBoard(){
+    const board = document.getElementById('game');
+    if(board.classList.contains('hidden')) return;
+    const diff = document.getElementById('difficulty').value;
+    let cols, rows;
+    if(document.getElementById('practice-toggle').checked){
+        const intervals = INTERVAL_SETS[diff];
+        cols = Math.ceil(Math.sqrt(intervals.length));
+        rows = Math.ceil(intervals.length/cols);
+    } else {
+        [cols, rows] = GRID_SIZES[diff];
+    }
+    setBoardSize(cols, rows);
+}
+
+window.addEventListener('resize', adjustBoard);

--- a/pitch-interval-memory-matching/style.css
+++ b/pitch-interval-memory-matching/style.css
@@ -1,10 +1,49 @@
-body {font-family: Arial, sans-serif; padding: 20px;}
-#controls {margin-bottom: 20px;}
-#game {display: grid; gap: 10px; justify-content: center;}
-.tile {
-    width: 80px; height: 80px; display: flex; align-items: center; justify-content: center;
-    background: #444; color: #fff; cursor: pointer; border-radius: 8px; position: relative;
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
+
+h1 {
+    text-align: center;
+}
+
+#controls {
+    margin-bottom: 20px;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    text-align: center;
+}
+
+#timer {
+    text-align: center;
+}
+
+#game {
+    display: grid;
+    gap: 10px;
+    flex-grow: 1;
+    place-content: center;
+}
+
+.tile {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #444;
+    color: #fff;
+    cursor: pointer;
+    border-radius: 8px;
+    position: relative;
+}
+
 .tile.revealed {background: #eee; color: #000;}
 .tile.matched {background: #8f8;}
 .tile.wrong {background: #f88;}


### PR DESCRIPTION
## Summary
- Center title and controls and convert page layout to flex-based, vertically centered design.
- Dynamically size game tiles based on window dimensions so board fills available space without overlapping controls.
- Recalculate board layout on window resize to maintain centered, responsive tile grid.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b863c70aac832092ad6d52d440b2ed