### PR TITLE
Adjust layout for pitch-interval memory matching game

### DIFF
--- a/pitch-interval-memory-matching/index.html
+++ b/pitch-interval-memory-matching/index.html
@@ -6,28 +6,29 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Pitch Interval Memory Matching</h1>
     <div id="controls">
-        <label><input type="checkbox" id="practice-toggle"> Practice Mode</label>
-        <label>Difficulty:
-            <select id="difficulty">
-                <option value="easy">Easy</option>
-                <option value="medium">Medium</option>
-                <option value="hard">Hard</option>
-                <option value="expert">Expert</option>
-            </select>
-        </label>
-        <label>Playback:
-            <select id="playback">
-                <option value="harmonic">Harmonic</option>
-                <option value="melodic-asc">Melodic Asc</option>
-                <option value="melodic-desc">Melodic Desc</option>
-            </select>
-        </label>
-        <label><input type="checkbox" id="timed"> Timed Run</label>
-        <button id="start">Start</button>
+        <div id="options">
+            <label><input type="checkbox" id="practice-toggle"> Practice Mode</label>
+            <label>Difficulty:
+                <select id="difficulty">
+                    <option value="easy">Easy</option>
+                    <option value="medium">Medium</option>
+                    <option value="hard">Hard</option>
+                    <option value="expert">Expert</option>
+                </select>
+            </label>
+            <label>Playback:
+                <select id="playback">
+                    <option value="harmonic">Harmonic</option>
+                    <option value="melodic-asc">Melodic Asc</option>
+                    <option value="melodic-desc">Melodic Desc</option>
+                </select>
+            </label>
+            <label><input type="checkbox" id="timed"> Timed Run</label>
+            <button id="start">Start</button>
+        </div>
+        <div id="timer" class="hidden">Time: <span id="time">0.0</span>s</div>
     </div>
-    <div id="timer" class="hidden">Time: <span id="time">0.0</span>s</div>
     <div id="game" class="hidden"></div>
     <script src="script.js"></script>
 </body>

--- a/pitch-interval-memory-matching/script.js
+++ b/pitch-interval-memory-matching/script.js
@@ -33,16 +33,13 @@ let timerInterval, startTime;
 
 function setBoardSize(cols, rows){
     const gap = 10; // match CSS gap
-    const header = document.querySelector('h1').offsetHeight;
-    const controls = document.getElementById('controls').offsetHeight;
-    const timer = document.getElementById('timer').offsetHeight;
-    const availableWidth = window.innerWidth - 20; // small margin
-    const availableHeight = window.innerHeight - header - controls - timer - 20;
+    const board = document.getElementById('game');
+    const availableWidth = board.clientWidth;
+    const availableHeight = board.clientHeight;
     const tileSize = Math.min(
         (availableWidth - gap * (cols - 1)) / cols,
         (availableHeight - gap * (rows - 1)) / rows
     );
-    const board = document.getElementById('game');
     board.style.gridTemplateColumns = `repeat(${cols}, ${tileSize}px)`;
     board.style.gridAutoRows = `${tileSize}px`;
 }
@@ -124,8 +121,7 @@ function generateTiles(diff){
 function buildBoard(diff){
     const board = document.getElementById('game');
     board.innerHTML='';
-    const {tiles, cols, rows} = generateTiles(diff);
-    setBoardSize(cols, rows);
+    const {tiles} = generateTiles(diff);
     tiles.forEach((t,i)=>{
         const div = document.createElement('div');
         div.className = 'tile';
@@ -164,7 +160,6 @@ function initGame(){
         const intervals = INTERVAL_SETS[diff];
         const cols = Math.ceil(Math.sqrt(intervals.length));
         const rows = Math.ceil(intervals.length/cols);
-        setBoardSize(cols, rows);
         intervals.forEach(interval => {
             const div = document.createElement('div');
             div.className = 'tile revealed';

--- a/pitch-interval-memory-matching/style.css
+++ b/pitch-interval-memory-matching/style.css
@@ -4,20 +4,23 @@ body {
     height: 100vh;
     display: flex;
     flex-direction: column;
-    align-items: center;
-}
-
-h1 {
-    text-align: center;
 }
 
 #controls {
-    margin-bottom: 20px;
+    height: 20vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    text-align: center;
+}
+
+#options {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
     gap: 10px;
-    text-align: center;
 }
 
 #timer {
@@ -25,9 +28,10 @@ h1 {
 }
 
 #game {
+    height: 80vh;
+    width: 100%;
     display: grid;
     gap: 10px;
-    flex-grow: 1;
     place-content: center;
 }
 


### PR DESCRIPTION
## Summary
- Allocate 20% of viewport height for controls and 80% for game tiles
- Remove page title and embed timer within controls section
- Compute tile size from game area to prevent overflow

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b866165da883209dc2c1a7fccee714