### PR TITLE
Center tiles and reduce size to 80%

### DIFF
--- a/pitch-interval-memory-matching/style.css
+++ b/pitch-interval-memory-matching/style.css
@@ -38,8 +38,8 @@ body {
 }
 
 .tile {
-    width: 100%;
-    height: 100%;
+    width: 80%;
+    height: 80%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -48,6 +48,7 @@ body {
     cursor: pointer;
     border-radius: 8px;
     position: relative;
+    place-self: center;
 }
 
 .tile.revealed {background: #eee; color: #000;}


### PR DESCRIPTION
## Summary
- Make memory tiles cover only 80% of their grid cells and center them for a uniform look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a2c0aac8320adc658108105dc02