### PR TITLE
Expand controls to fill section

### DIFF
--- a/pitch-interval-memory-matching/style.css
+++ b/pitch-interval-memory-matching/style.css
@@ -14,13 +14,22 @@ body {
     align-items: center;
     gap: 10px;
     text-align: center;
+    overflow: hidden;
 }
 
 #options {
     display: flex;
     justify-content: center;
+    align-items: stretch;
     flex-wrap: wrap;
     gap: 10px;
+    width: 80%;
+    height: 80%;
+}
+
+#options > * {
+    flex: 1 1 30%;
+    max-width: 100%;
 }
 
 #timer {


### PR DESCRIPTION
## Summary
- Make pitch interval controls occupy 80% of their container
- Stretch control elements to fill available space without scrollbars

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b870b62f348320b4295bc0d53d37de