### PR TITLE
Use Tone.js for interval playback and feedback

### DIFF
--- a/pitch-interval-memory-matching/index.html
+++ b/pitch-interval-memory-matching/index.html
@@ -30,6 +30,7 @@
         <div id="timer" class="hidden">Time: <span id="time">0.0</span>s</div>
     </div>
     <div id="game" class="hidden"></div>
+    <script src="https://cdn.jsdelivr.net/npm/tone@latest"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Tone.js via CDN and initialize PolySynth and feedback synth in the game.
- Rework interval playback and feedback cues using Tone.Transport and Tone's envelopes.
- Start Tone's audio context on user interaction.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bbf0ed6883209a3277fbf0184467