### PR TITLE
fix: display tiles after showing board

### DIFF
--- a/pitch-interval-memory-matching/script.js
+++ b/pitch-interval-memory-matching/script.js
@@ -223,7 +223,7 @@ function initGame(){
         });
         if(timed) startTimer();
     }
-    adjustBoard();
+    requestAnimationFrame(adjustBoard);
 }
 
 document.getElementById('start').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- Delay board size adjustment until after the board is visible

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/music-games/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c3bebab1a0832090d8afca20b1ae16