### PR TITLE
Add hard mode without interval labels

### DIFF
--- a/pitch-interval-memory-matching/index.html
+++ b/pitch-interval-memory-matching/index.html
@@ -16,7 +16,7 @@
     <p class="text-neutral-400">Match pairs by <em>ear</em>. Click two tiles; if they’re the same interval, they stay revealed.</p>
   </header>
 
-  <section class="grid gap-4 mb-4 md:grid-cols-3">
+  <section class="grid gap-4 mb-4 md:grid-cols-4">
     <div class="bg-neutral-900 rounded-xl p-4 space-y-2">
       <div class="text-sm text-neutral-400">Playback</div>
       <select id="mode" class="w-full bg-neutral-800 rounded-lg px-3 py-2">
@@ -43,6 +43,14 @@
         <option value="chromatic2oct">All 12, extended to 2 octaves</option>
       </select>
       <div class="text-xs text-neutral-500">All intervals in semitones, equal temperament.</div>
+    </div>
+
+    <div class="bg-neutral-900 rounded-xl p-4 space-y-2">
+      <div class="text-sm text-neutral-400">Difficulty</div>
+      <select id="difficulty" class="w-full bg-neutral-800 rounded-lg px-3 py-2">
+        <option value="easy">Easy</option>
+        <option value="hard">Hard (no labels)</option>
+      </select>
     </div>
   </section>
 

--- a/pitch-interval-memory-matching/js/game.js
+++ b/pitch-interval-memory-matching/js/game.js
@@ -7,6 +7,7 @@ const modeSel = el('mode');
 const pairsInput = el('pairs');
 const pairsVal = el('pairsVal');
 const intervalSetSel = el('intervalSet');
+const difficultySel = el('difficulty');
 const rootMin = el('rootMin');
 const rootMax = el('rootMax');
 const newGameBtn = el('newGame');
@@ -55,7 +56,7 @@ function drawGrid() {
     front.innerHTML = "？";
     const back = document.createElement('div');
     back.className = "face back absolute inset-0 flex items-center justify-center rounded-xl bg-emerald-700/30 text-emerald-300 font-semibold select-none";
-    back.innerText = t.label;
+    back.innerText = (difficultySel.value === 'hard') ? '' : t.label;
     card.appendChild(front);
     card.appendChild(back);
 
@@ -137,6 +138,7 @@ export function newGame() {
 export function setupControls() {
   pairsInput.addEventListener('input', e => { pairsVal.textContent = e.target.value; });
   newGameBtn.addEventListener('click', () => { round = 1; roundEl.textContent = round; newGame(); });
+  difficultySel.addEventListener('change', () => drawGrid());
   replayAllBtn.addEventListener('click', async () => {
     await ensureAudio();
     let t = 0;


### PR DESCRIPTION
## Summary
- Add Difficulty selector allowing Easy or Hard (no labels) modes
- In Hard mode, tiles hide interval labels while preserving current gameplay in Easy mode

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c42aadb5008320866b05b45568c8ac